### PR TITLE
Cleans up ESLint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ dist
 
 ## Pycharm IDE
 .idea
-.vscode

--- a/.vscode
+++ b/.vscode
@@ -1,0 +1,1 @@
+/Users/madsnedergaard/dev/work/rewrite/web/.vscode

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -20,6 +20,10 @@
     "prettier"
   ],
   "rules": {
+    // TODO: TEMPORARILY DISABLED DURING INITIAL DEVELOPMENT
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-empty-function": "off",
+
     "no-promise-executor-return": "error",
     "no-unreachable-loop": "error",
     "require-atomic-updates": "error",

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -54,9 +54,10 @@
       "error",
       {
         "ignoreEnums": true,
-        "ignore": [0],
+        "ignore": [-1, 0, 1, 60, 1000],
+        "ignoreArrayIndexes": true,
         "enforceConst": true,
-        "detectObjects": true
+        "detectObjects": false
       }
     ],
     "@typescript-eslint/no-confusing-void-expression": ["error", { "ignoreArrowShorthand": true }],

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -8,25 +8,20 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["react-prefer-function-component"],
   "extends": [
-    "eslint:all",
-    "plugin:@typescript-eslint/all",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript",
-    "plugin:react/all",
+    "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
-    "airbnb",
-    "airbnb-typescript",
-    "airbnb/hooks",
     "plugin:react/jsx-runtime",
-    "plugin:unicorn/all",
+    "plugin:unicorn/recommended",
     "plugin:react-prefer-function-component/recommended",
     "prettier"
   ],
   "rules": {
-    "no-dupe-else-if": "error",
     "no-promise-executor-return": "error",
     "no-unreachable-loop": "error",
-    "no-useless-backreference": "error",
     "require-atomic-updates": "error",
     "default-case-last": "error",
     "grouped-accessor-pairs": "error",
@@ -51,10 +46,6 @@
     ],
     "no-void": "off",
 
-    "@typescript-eslint/padding-line-between-statements": "off",
-    "@typescript-eslint/prefer-enum-initializers": "off",
-    "@typescript-eslint/prefer-readonly-parameter-types": "off",
-    "@typescript-eslint/prefer-regexp-exec": "off",
     "@typescript-eslint/no-magic-numbers": [
       "error",
       {
@@ -64,18 +55,9 @@
         "detectObjects": true
       }
     ],
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/init-declarations": "off",
     "@typescript-eslint/no-confusing-void-expression": ["error", { "ignoreArrowShorthand": true }],
-    "@typescript-eslint/non-nullable-type-assertion-style": "off",
-    "@typescript-eslint/strict-boolean-expressions": "off",
-    "@typescript-eslint/no-implicit-any-catch": "off",
-    "@typescript-eslint/member-ordering": "off",
-    "@typescript-eslint/prefer-includes": "off",
-    "@typescript-eslint/no-restricted-imports": "off",
-
     "import/no-deprecated": "error",
-    "import/order": "off",
+    "import/no-unresolved": "off", // Off as TS handles this
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -90,22 +72,17 @@
       }
     ],
 
-    "react/no-did-update-set-state": "off",
-    "react/no-find-dom-node": "off",
-    "react/no-is-mounted": "off",
-    "react/no-redundant-should-component-update": "off",
-    "react/no-render-return-value": "off",
-    "react/no-string-refs": "off",
-    "react/no-this-in-sfc": "off",
-    "react/no-will-update-set-state": "off",
-    "react/prefer-es6-class": "off",
-    "react/no-unused-state": "off",
-    "react/prefer-stateless-function": "off",
-    "react/require-render-return": "off",
-    "react/sort-comp": "off",
-    "react/state-in-constructor": "off",
-    "react/static-property-placement": "off",
-
+    // Commented out as I don't think they were running anyway?
+    // "react/no-string-refs": "off",
+    // "react/no-this-in-sfc": "off",
+    // "react/no-will-update-set-state": "off",
+    // "react/prefer-es6-class": "off",
+    // "react/no-unused-state": "off",
+    // "react/prefer-stateless-function": "off",
+    // "react/sort-comp": "off",
+    // "react/state-in-constructor": "off",
+    // "react/static-property-placement": "off",
+    "react/prop-types": "off",
     "react/boolean-prop-naming": [
       "error",
       {
@@ -128,7 +105,6 @@
         "checkInlineFunction": true
       }
     ],
-    "react/jsx-key": "error",
     "react/jsx-no-bind": [
       "error",
       {
@@ -177,6 +153,7 @@
       "extends": ["plugin:testing-library/react"],
       "rules": {
         "@typescript-eslint/no-magic-numbers": ["off"],
+        "import/default": "off",
         "testing-library/no-await-sync-events": [
           "error",
           {

--- a/web/.vscode/extensions.json
+++ b/web/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "bradlc.vscode-tailwindcss",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "visualstudioexptteam.vscodeintellicode"
+  ]
+}

--- a/web/.vscode/settings.json
+++ b/web/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "editor.codeActionsOnSave": ["source.addMissingImports", "source.fixAll", "source.organizeImports"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "files.exclude": {
+    "**/.eslintcache": true,
+    "**/.gitignore": true,
+    "**/.nyc_output": true,
+    "**/.vscode": true,
+    "**/dist": true,
+    "**/node_modules": true,
+    "**/yarn.lock": true,
+    "**/coverage": true
+  },
+  "files.watcherExclude": {
+    "**/dist": true
+  },
+  "git.enableCommitSigning": true,
+  "javascript.format.enable": false,
+  "typescript.disableAutomaticTypeAcquisition": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -1,7 +1,7 @@
 import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import type { GridState, TimeAverages } from 'types';
-import { getBasePath, getHeaders, QUERY_KEYS } from './helpers';
+import { getBasePath, getHeaders, QUERY_KEYS, REFETCH_INTERVAL_MS } from './helpers';
 
 const getState = async (timeAverage: string): Promise<GridState> => {
   const path = `/v5/state/${timeAverage}`;
@@ -22,7 +22,7 @@ const getState = async (timeAverage: string): Promise<GridState> => {
 
 const useGetState = (timeAverage: TimeAverages, options?: UseQueryOptions<GridState>): UseQueryResult<GridState> =>
   useQuery<GridState>([QUERY_KEYS.STATE, timeAverage], async () => getState(timeAverage), {
-    staleTime: 1000 * 60 * 5,
+    staleTime: REFETCH_INTERVAL_MS,
     ...options,
   });
 

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -1,7 +1,7 @@
 import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import type { TimeAverages, ZoneDetails } from 'types';
-import { getHeaders, getBasePath, QUERY_KEYS } from './helpers';
+import { getHeaders, getBasePath, QUERY_KEYS, REFETCH_INTERVAL_MS } from './helpers';
 
 const getZone = async (zoneId: string, timeAverage: TimeAverages): Promise<ZoneDetails> => {
   const path = `/v5/history/${timeAverage}?countryCode=${zoneId}`;
@@ -26,7 +26,7 @@ const useGetZone = (
   options?: UseQueryOptions<ZoneDetails>
 ): UseQueryResult<ZoneDetails> =>
   useQuery<ZoneDetails>([QUERY_KEYS.ZONE, zoneId], async () => getZone(zoneId, timeAverage), {
-    staleTime: 1000 * 60 * 5,
+    staleTime: REFETCH_INTERVAL_MS,
     ...options,
   });
 

--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -1,5 +1,8 @@
 import invariant from 'tiny-invariant';
 
+const REFETCH_INTERVAL_MINUTES = 5;
+export const REFETCH_INTERVAL_MS = REFETCH_INTERVAL_MINUTES * 60 * 1000;
+
 async function sha256(message: string): Promise<string> {
   const BASE = 16;
   const MAX_LENGTH = 2;

--- a/web/src/components/__tests__/Fruit.tsx
+++ b/web/src/components/__tests__/Fruit.tsx
@@ -33,7 +33,6 @@ describe('<Fruit />', () => {
     await userEvent.keyboard('a');
     await userEvent.keyboard('[Enter]');
 
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('apple');
   });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,11 +5,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { registerSW } from 'virtual:pwa-register';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import './index.css';
+import { REFETCH_INTERVAL_MS } from 'api/helpers';
 
 registerSW();
 
 const MAX_RETRIES = 1;
-const REFETCH_INTERVAL_MS = 1000 * 60 * 5; // 5 minutes
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -48,6 +48,7 @@ beforeAll(() => {
   });
   Object.defineProperty(window, 'scrollTo', {
     writable: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     value: () => {},
   });
   Object.defineProperty(window, 'resizeTo', {

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -30,7 +30,6 @@ beforeAll(() => {
         removeEventListener: (_: 'change', listener: () => void): void => {
           const index = listeners.indexOf(listener);
           if (index >= 0) {
-            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
             listeners.splice(index, 1);
           }
         },
@@ -48,7 +47,6 @@ beforeAll(() => {
   });
   Object.defineProperty(window, 'scrollTo', {
     writable: true,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     value: () => {},
   });
   Object.defineProperty(window, 'resizeTo', {

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 
-// eslint-disable-next-line import/prefer-default-export
+ 
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(() => matchMedia(query).matches);
 


### PR DESCRIPTION
## Description

Changes from "all" to "recommended" for all plugins.
Adjusts some rules.
Also added the `.vscode` folder that was gitignored and a symlink so you can open both `web` and `/` in VSCode and still get the same settings.

### TBD

There's some rules here about larger patterns we should discuss!

1. **Filenames** Keep
`PascalCase` for components, `camelCase` for everything else?
(The is default in the starter, but we can do whatever)

2. **Declaring components** Discuss
It can be done in a bunch of different ways in JS. Should we enforce strictness around this?
Starter uses `react/function-component-definition: [“error”, {“namedComponents”: “function-declaration”}]`which means this:

```js
// incorrect (arrow function)
const CoolComponent = ({name}) => <div>{name}</div>

// correct
function CoolComponent({ name }) {
  return <div>{name}</div>;
}
```
3. **explicit-function-return-type** Remove
```
// incorrect because it doesn't have a :boolean return type explicit
function isBoolean(value) {
  return true;
}
```

4. type alias Discuss

5. **Absolute imports** Prefix with ~
To prefix imports or not?
E.g. `import X from @components/whatever` vs `import X from components/whatever`
If yes, use `@` or `~`?
