### PR TITLE
Adds error overlay to display runtime errors

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,8 +6,13 @@ import { registerSW } from 'virtual:pwa-register';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import './index.css';
 import { REFETCH_INTERVAL_MS } from 'api/helpers';
+import showErrorsInOverlay from 'utils/errorOverlay';
 
 registerSW();
+
+if (import.meta.env.DEV) {
+  showErrorsInOverlay();
+}
 
 const MAX_RETRIES = 1;
 const queryClient = new QueryClient({

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,7 +11,7 @@ import enableErrorsInOverlay from 'utils/errorOverlay';
 registerSW();
 
 if (import.meta.env.DEV) {
-  showErrorsInOverlay();
+  enableErrorsInOverlay();
 }
 
 const MAX_RETRIES = 1;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,7 +6,7 @@ import { registerSW } from 'virtual:pwa-register';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import './index.css';
 import { REFETCH_INTERVAL_MS } from 'api/helpers';
-import showErrorsInOverlay from 'utils/errorOverlay';
+import enableErrorsInOverlay from 'utils/errorOverlay';
 
 registerSW();
 

--- a/web/src/utils/errorOverlay.ts
+++ b/web/src/utils/errorOverlay.ts
@@ -11,7 +11,7 @@ const showErrorOverlay = (error: Error) => {
   document.body.append(overlay);
 };
 
-export default function showErrorsInOverlay() {
+export default function enableErrorsInOverlay() {
   window.addEventListener('error', ({ error }) => showErrorOverlay(error));
   window.addEventListener('unhandledrejection', ({ reason }) => showErrorOverlay(reason));
 }

--- a/web/src/utils/errorOverlay.ts
+++ b/web/src/utils/errorOverlay.ts
@@ -1,0 +1,17 @@
+// Source: https://github.com/vitejs/vite/issues/2076#issuecomment-846558772
+const showErrorOverlay = (error: Error) => {
+  // Must be within function call because that's when the element is defined for sure.
+  const ErrorOverlay = customElements.get('vite-error-overlay');
+  // Don't open outside vite environment
+  if (!ErrorOverlay) {
+    return;
+  }
+  console.log(error);
+  const overlay = new ErrorOverlay(error);
+  document.body.append(overlay);
+};
+
+export default function showErrorsInOverlay() {
+  window.addEventListener('error', ({ error }) => showErrorOverlay(error));
+  window.addEventListener('unhandledrejection', ({ reason }) => showErrorOverlay(reason));
+}


### PR DESCRIPTION
## Description

Ensure more runtime errors are shown in an error modal to make life easier while developing.

### Before
<img width="1109" alt="Screenshot 2022-11-02 at 20 21 25" src="https://user-images.githubusercontent.com/3296643/199582293-e71df928-ec04-4dbb-8e34-98816d6c4bd3.png">


### After

<img width="993" alt="Screenshot 2022-11-02 at 20 21 47" src="https://user-images.githubusercontent.com/3296643/199582252-2d9f59b0-7a42-4cb2-aade-e1aa220e52c7.png">

