### PR TITLE
less fruits, more clickable map

### DIFF
--- a/web/src/api/getFruits.ts
+++ b/web/src/api/getFruits.ts
@@ -1,6 +1,0 @@
-import type { IFruit } from 'types';
-
-export default async function getFruits(): Promise<IFruit[]> {
-  const response = await fetch('https://614c99f03c438c00179faa84.mockapi.io/fruits');
-  return response.json() as Promise<IFruit[]>;
-}

--- a/web/src/components/MapButton.tsx
+++ b/web/src/components/MapButton.tsx
@@ -16,7 +16,7 @@ export default function MapButton(properties: MapButtonProperties): ReactElement
     <TooltipWrapper tooltipText={tooltipText}>
       <Toggle.Root
         onClick={onClick}
-        className={`Toggle flex h-8 w-8 items-center justify-center rounded bg-white  drop-shadow dark:bg-gray-900 ${className}`}
+        className={`Toggle pointer-events-auto flex h-8 w-8 items-center justify-center rounded bg-white  drop-shadow dark:bg-gray-900 ${className}`}
         aria-label="Toggle italic"
       >
         <div>{icon}</div>

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -12,8 +12,8 @@ export default function MapControls(properties: MapControlsProperties): ReactEle
   const { __ } = useTranslation();
 
   return (
-    <div className="z-1000 absolute  right-3 top-3 flex flex-col items-end">
-      <div className="mb-16 flex flex-col items-end">
+    <div className="z-1000 pointer-events-none  absolute right-3 top-3 flex flex-col items-end">
+      <div className="pointer-events-auto mb-16 flex flex-col items-end">
         <ConsumptionProductionToggle />
         <div className="mb-1"></div>
         <SpatialAggregatesToggle />


### PR DESCRIPTION
## Issue

## Description

Make the div behind the map-controls pass through click events and remove legacy fruits api
