### PR TITLE
BreakdownChartTooltip bugfixes

### DIFF
--- a/web/src/features/charts/tooltipCalculations.test.ts
+++ b/web/src/features/charts/tooltipCalculations.test.ts
@@ -164,6 +164,16 @@ describe('getProductionTooltipData', () => {
     };
     expect(actual).toEqual(expected);
   });
+
+  it('returns 0 usage for zero production', () => {
+    const actual = getProductionTooltipData('solar', zoneDetailsData, false);
+    expect(actual.usage).toEqual(0);
+  });
+
+  it('returns nan usage for null production', () => {
+    const actual = getProductionTooltipData('geothermal', zoneDetailsData, false);
+    expect(actual.usage).toEqual(Number.NaN);
+  });
 });
 
 describe('getExchangeTooltipData', () => {

--- a/web/src/features/charts/tooltipCalculations.test.ts
+++ b/web/src/features/charts/tooltipCalculations.test.ts
@@ -119,7 +119,7 @@ describe('getProductionTooltipData', () => {
       totalEmissions: 13_208_019_616.973_745,
       production: 41_161,
       zoneKey: 'FR',
-      storage: 0,
+      storage: undefined,
       isExport: false,
       emissions: 211_155_930,
       usage: 41_161,
@@ -138,10 +138,29 @@ describe('getProductionTooltipData', () => {
       totalEmissions: 13_208_019_616.973_745,
       production: 41_161,
       zoneKey: 'FR',
-      storage: 0,
+      storage: undefined,
       isExport: false,
       emissions: 211_155_930,
       usage: 211_155_930,
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns correct data for hydro storage', () => {
+    const actual = getProductionTooltipData('hydro storage', zoneDetailsData, false);
+    const expected = {
+      capacity: 20_222.25,
+      co2Intensity: 54.190_888_929_032_22,
+      co2IntensitySource: 'Electricity Maps, 2021 average',
+      displayByEmissions: false,
+      totalElectricity: 84_545.75,
+      totalEmissions: 13_208_019_616.973_745,
+      production: 11_930.25,
+      zoneKey: 'FR',
+      storage: -3738.75,
+      isExport: false,
+      emissions: 202_606_185.983_419_2,
+      usage: 3738.75,
     };
     expect(actual).toEqual(expected);
   });

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -1,4 +1,4 @@
-import { ElectricityStorageType, GenerationType, ZoneDetail } from 'types';
+import { ElectricityStorageKeyType, GenerationType, ZoneDetail } from 'types';
 import { getProductionCo2Intensity } from 'utils/helpers';
 import { getElectricityProductionValue, getTotalElectricity } from './graphUtils';
 
@@ -8,8 +8,13 @@ export function getProductionTooltipData(
   displayByEmissions: boolean
 ) {
   const co2Intensity = getProductionCo2Intensity(selectedLayerKey, zoneDetail);
-  const generationType = selectedLayerKey as GenerationType;
-  const isStorage = generationType.includes('storage');
+  const isStorage = selectedLayerKey.includes('storage');
+
+  const generationType = isStorage
+    ? (selectedLayerKey.replace(' storage', '') as GenerationType)
+    : (selectedLayerKey as GenerationType);
+
+  const storageKey = generationType as ElectricityStorageKeyType;
 
   const totalElectricity = getTotalElectricity(zoneDetail, displayByEmissions);
   const totalEmissions = getTotalElectricity(zoneDetail, true);
@@ -24,15 +29,13 @@ export function getProductionTooltipData(
   } = zoneDetail;
 
   const co2IntensitySource = isStorage
-    ? (dischargeCo2IntensitySources || {})[generationType]
+    ? (dischargeCo2IntensitySources || {})[storageKey]
     : (productionCo2IntensitySources || {})[generationType];
 
   const generationTypeCapacity = capacity[generationType];
   const generationTypeProduction = production[generationType];
-  const storageType = isStorage
-    ? (generationType.replace('storage', '') as ElectricityStorageType)
-    : undefined;
-  const generationTypeStorage = storageType ? storage[storageType] : 0;
+
+  const generationTypeStorage = storageKey ? storage[storageKey] : 0;
 
   const electricity = getElectricityProductionValue({
     generationTypeCapacity,

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -52,9 +52,6 @@ export function getProductionTooltipData(
     usage = Math.abs(
       displayByEmissions ? electricity * co2Intensity * 1000 : electricity
     );
-  }
-
-  if (Number.isFinite(electricity)) {
     emissions = Math.abs(electricity * co2Intensity * 1000);
   }
 

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -44,14 +44,19 @@ export function getProductionTooltipData(
     generationTypeProduction,
   });
   const isExport = electricity < 0;
-  const usage =
-    (Number.isFinite(electricity) &&
-      Math.abs(displayByEmissions ? electricity * co2Intensity * 1000 : electricity)) ||
-    Number.NaN;
 
-  const emissions =
-    (Number.isFinite(electricity) && Math.abs(electricity * co2Intensity * 1000)) ||
-    Number.NaN;
+  let usage = Number.NaN;
+  let emissions = Number.NaN;
+
+  if (Number.isFinite(electricity)) {
+    usage = Math.abs(
+      displayByEmissions ? electricity * co2Intensity * 1000 : electricity
+    );
+  }
+
+  if (Number.isFinite(electricity)) {
+    emissions = Math.abs(electricity * co2Intensity * 1000);
+  }
 
   return {
     co2Intensity,

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -11,14 +11,20 @@ interface AreaGraphTooltipProperties {
   dataPoint?: AreaGraphElement;
   position?: { x: number; y: number } | undefined;
   tooltipSize?: 'small' | 'large';
-  isMinSM: boolean;
+  isBiggerThanMobile: boolean;
 }
 
 export default function AreaGraphTooltip(
   properties: AreaGraphTooltipProperties
 ): ReactElement | null {
-  const { children, zoneDetail, selectedLayerKey, position, tooltipSize, isMinSM } =
-    properties;
+  const {
+    children,
+    zoneDetail,
+    selectedLayerKey,
+    position,
+    tooltipSize,
+    isBiggerThanMobile,
+  } = properties;
 
   if (
     children === undefined ||
@@ -32,7 +38,7 @@ export default function AreaGraphTooltip(
     mousePositionX: position?.x || 0,
     mousePositionY: position?.y || 0,
     tooltipHeight: tooltipSize === 'large' ? 360 : 160,
-    isMinSM,
+    isBiggerThanMobile,
   });
 
   return (

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -129,7 +129,7 @@ export function BreakdownChartTooltipContent(
       ); // Eg: "20 % of electricity in Denmark comes from biomass"
 
   return (
-    <div className="w-full rounded-md bg-white p-3 text-sm shadow-3xl sm:w-[410px]">
+    <div className="w-full rounded-md bg-white p-3 text-sm shadow-3xl dark:bg-gray-900 sm:w-[410px]">
       <AreaGraphToolTipHeader
         squareColor={
           isExchange ? co2ColorScale(co2Intensity) : modeColor[selectedLayerKey]

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -20,7 +20,7 @@ export default function CarbonChartTooltip(props: InnerAreaGraphTooltipProps) {
   const { co2intensity, stateDatetime } = zoneDetail;
 
   return (
-    <div className="w-full rounded-md bg-white p-3 shadow-xl sm:w-80">
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-80">
       <div className="flex justify-between">
         <div className="inline-flex items-center gap-x-1">
           <div

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -20,7 +20,7 @@ export default function EmissionChartTooltip(props: InnerAreaGraphTooltipProps) 
   const { stateDatetime } = zoneDetail;
 
   return (
-    <div className="w-full rounded-md bg-white p-3 shadow-xl sm:w-[350px]">
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-[350px]">
       <AreaGraphToolTipHeader
         datetime={new Date(stateDatetime)}
         timeAverage={timeAverage}

--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -17,7 +17,7 @@ export default function PriceChartTooltip(props: InnerAreaGraphTooltipProps) {
   const value = priceIsDefined ? price?.value : '';
 
   return (
-    <div className="w-full rounded-md bg-white p-3 shadow-xl sm:w-64">
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-64">
       <AreaGraphToolTipHeader
         datetime={new Date(stateDatetime)}
         timeAverage={timeAverage}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig(({ mode }) => ({
     clearMocks: true,
     coverage: {
       provider: 'istanbul',
-      enabled: true,
+      enabled: false,
       '100': true,
       reporter: ['text', 'lcov'],
       reportsDirectory: 'coverage',


### PR DESCRIPTION
## Issue

## Description

- Ensures hydro storage correctly shows instead of '?'
- Ensures production that is 0 is shown as 0 instead of '?' and null production is shown as '?'

Also added some tests.
