### PR TITLE
🎁 Provides extra space in zonedetails

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -14,6 +14,8 @@ import BarBreakdownProductionChart from './BarBreakdownProductionChart';
 import BySource from './BySource';
 import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
 
+const X_PADDING = 9;
+
 function BarBreakdownChart() {
   const {
     currentZoneDetail,
@@ -24,7 +26,7 @@ function BarBreakdownChart() {
     height,
   } = useBarBreakdownChartData();
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const { ref, width } = useReferenceWidthHeightObserver();
+  const { ref, width } = useReferenceWidthHeightObserver(X_PADDING);
   const { __ } = useTranslation();
   const isBiggerThanMobile = useBreakpoint('sm');
 

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -86,9 +86,7 @@ function OuterPanel({ children }: { children: React.ReactNode }) {
       } ${!isOpen ? '-translate-x-full' : ''}`}
     >
       <MobileHeader />
-      <section className="h-full w-full overflow-y-scroll p-2 pl-1 pr-0 sm:pr-2">
-        {children}
-      </section>
+      <section className="h-full w-full p-2 pl-1 pr-0">{children}</section>
       <CollapseButton isCollapsed={!isOpen} onCollapse={onCollapse} />
     </aside>
   );


### PR DESCRIPTION
## Issue

## Description

We had two elements with overflow, which created a lot of extra space.

I also add some padding to the barbreakdownchart as it was slightly misaligned with the areagraphcharts

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

Before:
![image](https://user-images.githubusercontent.com/45588799/209126726-f8bb29ef-3390-428d-8d37-21448a22bd53.png)


Now: 
![image](https://user-images.githubusercontent.com/45588799/209126530-1adf35f8-45af-470d-afb6-0253d7b02a66.png)



