### PR TITLE
🎁 Improve tooltip interactivity on mobile

### DIFF
--- a/web/src/components/tooltips/utilities.ts
+++ b/web/src/components/tooltips/utilities.ts
@@ -42,7 +42,7 @@ export const getOffsetTooltipPosition = ({
   if (!isBiggerThanMobile) {
     return {
       x: 0,
-      y: 40, // Provides space for the header to still be visible
+      y: 0,
     };
   }
 

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -78,7 +78,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 sm:block sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 pt-14 sm:block sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -2,6 +2,7 @@ import * as Portal from '@radix-ui/react-portal';
 import { getOffsetTooltipPosition } from 'components/tooltips/utilities';
 import { useAtom } from 'jotai';
 import React, { useState } from 'react';
+import { HiXMark } from 'react-icons/hi2';
 import { useTranslation } from 'translation/translation';
 import { ZoneDetail } from 'types';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
@@ -77,7 +78,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="pointer-events-none absolute left-0 top-0 h-full w-full bg-black/20 p-2 sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,
@@ -87,6 +88,9 @@ function BarBreakdownChart() {
             selectedLayerKey={tooltipData?.selectedLayerKey}
             zoneDetail={currentZoneDetail}
           />
+          <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900 sm:hidden">
+            <HiXMark size="24" />
+          </button>
         </Portal.Root>
       )}
       {displayByEmissions ? (

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -78,7 +78,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="pointer-events-auto absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 pt-14 sm:block sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 pt-14 sm:block sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -77,7 +77,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="absolute left-0 top-0 h-full w-full bg-black/20 p-2 sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-none absolute left-0 top-0 h-full w-full bg-black/20 p-2 sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -78,7 +78,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 pt-14 sm:block sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-auto absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 pt-14 sm:block sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -78,7 +78,7 @@ function BarBreakdownChart() {
       <BySource />
       {tooltipData && (
         <Portal.Root
-          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 sm:h-0 sm:w-0 sm:p-0"
+          className="pointer-events-auto absolute left-0 top-0 flex h-full w-full flex-col items-center gap-y-1 bg-black/20 p-2 sm:block sm:h-0 sm:w-0 sm:p-0"
           style={{
             left: tooltipData?.x,
             top: tooltipData?.y,

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -100,7 +100,7 @@ function AreaGraphLayers({
         return (
           <React.Fragment key={layer.key}>
             <path
-              className={layers.length > 1 ? 'hover:opacity-75' : ''}
+              className={layers.length > 1 ? 'sm:hover:opacity-75' : ''}
               style={{ cursor: 'pointer' }}
               stroke={layer.stroke}
               fill={isGradient ? `url(#${gradientId})` : layer.fill}

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -1,5 +1,6 @@
 import * as Portal from '@radix-ui/react-portal';
 import type { ReactElement } from 'react';
+import { HiXMark } from 'react-icons/hi2';
 import { ZoneDetail } from 'types';
 import { getOffsetTooltipPosition } from '../../../components/tooltips/utilities';
 import { AreaGraphElement, InnerAreaGraphTooltipProps } from '../types';
@@ -48,9 +49,12 @@ export default function AreaGraphTooltip(
           left: tooltipWithDataPositon.x,
           top: tooltipWithDataPositon.y,
         }}
-        className="relative flex p-2 sm:block sm:p-0"
+        className="relative flex flex-col items-center gap-y-1 p-2 sm:block sm:p-0"
       >
         {children({ zoneDetail, selectedLayerKey })}
+        <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900">
+          <HiXMark size="24" />
+        </button>
       </div>
     </Portal.Root>
   );

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -43,7 +43,7 @@ export default function AreaGraphTooltip(
   });
 
   return (
-    <Portal.Root className="pointer-events-none absolute left-0 top-0 h-full w-full bg-black/20 sm:h-0 sm:w-0">
+    <Portal.Root className="pointer-events-auto absolute left-0 top-0 h-full w-full bg-black/20 sm:h-0 sm:w-0">
       <div
         style={{
           left: tooltipWithDataPositon.x,
@@ -52,7 +52,7 @@ export default function AreaGraphTooltip(
         className="relative flex flex-col items-center gap-y-1 p-2 sm:block sm:p-0"
       >
         {children({ zoneDetail, selectedLayerKey })}
-        <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900">
+        <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900 sm:hidden">
           <HiXMark size="24" />
         </button>
       </div>

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -43,13 +43,13 @@ export default function AreaGraphTooltip(
   });
 
   return (
-    <Portal.Root className="pointer-events-auto absolute left-0 top-0 h-full w-full bg-black/20 sm:h-0 sm:w-0">
+    <Portal.Root className="pointer-events-auto absolute left-0 top-0 z-50 h-full w-full bg-black/20 sm:h-0 sm:w-0">
       <div
         style={{
           left: tooltipWithDataPositon.x,
           top: tooltipWithDataPositon.y,
         }}
-        className="relative flex flex-col items-center gap-y-1 p-2 sm:block sm:p-0"
+        className="relative flex flex-col items-center gap-y-1 p-2 pt-14 sm:block sm:p-0"
       >
         {children({ zoneDetail, selectedLayerKey })}
         <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900 sm:hidden">

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -43,7 +43,7 @@ export default function AreaGraphTooltip(
   });
 
   return (
-    <Portal.Root className="pointer-events-auto absolute left-0 top-0 z-50 h-full w-full bg-black/20 sm:h-0 sm:w-0">
+    <Portal.Root className="pointer-events-none absolute left-0 top-0 z-50 h-full w-full bg-black/20 sm:h-0 sm:w-0">
       <div
         style={{
           left: tooltipWithDataPositon.x,

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -14,7 +14,7 @@ import WindLayer from 'features/weather-layers/wind-layer/WindLayer';
 import { useAtom, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { createToWithState, getCO2IntensityByMode } from 'utils/helpers';
-import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
+import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import CustomLayer from './map-utils/CustomLayer';
 import { useGetGeometries } from './map-utils/getMapGrid';
 import {
@@ -131,6 +131,7 @@ export default function MapPage(): ReactElement {
   }, [mapReference, geometries, data, getCo2colorScale, selectedDatetime]);
 
   const onClick = (event: mapboxgl.MapLayerMouseEvent) => {
+    setHoveredZone(hoveredZone);
     const map = mapReference.current?.getMap();
     if (!map || !event.features) {
       return;


### PR DESCRIPTION
## Issue

## Description

Had a lot of issues navigating with the tooltips on mobile, specifically closing and opening tooltips was annoying. I figured it might be good to have a dismiss button alongside the tooltips so users can close it.

In terms of code, in this implementation the button doesn't actually do anything, but magically closes the tooltip because the event is considered a onLeave. That might not work as flawlessly on capacitor?

- Adds some CSS styling to make interactions more intuitive on mobile
- Adds an X button which can be used to close down the tooltip on mobile


<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
![image](https://user-images.githubusercontent.com/45588799/209315969-0d848558-b4ef-4f6f-a0cb-4087e9d3ecba.png)
