### PR TITLE
🎁 Update bottom sheet snap points

### DIFF
--- a/web/src/features/time/TimeControllerWrapper.tsx
+++ b/web/src/features/time/TimeControllerWrapper.tsx
@@ -5,8 +5,7 @@ import { useBreakpoint } from 'utils/styling';
 import TimeController from './TimeController';
 import TimeHeader from './TimeHeader';
 
-// These snap points should leave enough "safe area" at the bottom
-const SNAP_POINTS = [80, 200];
+const SNAP_POINTS = [60, 160];
 
 function BottomSheetWrappedTimeController() {
   const [isLoadingMap] = useAtom(loadingMapAtom);

--- a/web/src/features/time/TimeHeader.tsx
+++ b/web/src/features/time/TimeHeader.tsx
@@ -21,7 +21,9 @@ export default function TimeHeader({ className }: TimeHeaderProps) {
 
   return (
     <div
-      className={`flex flex-row items-center justify-between sm:pb-2 ${className || ''}`}
+      className={`flex flex-row items-baseline justify-between sm:pb-2 ${
+        className || ''
+      }`}
     >
       <p className="select-none text-base font-bold">{__('time-controller.title')}</p>
       <div


### PR DESCRIPTION
## Issue

![image](https://user-images.githubusercontent.com/45588799/209318617-ca395e57-c8a2-44fa-9b19-17c4f2312aed.png)


## Description

I don't think we should use the snapshots to provide extra safe area. It doesn't seem to work on web mobile anyways.

Perhaps this newer version of bottomsheet does it automagically?

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

Now

![image](https://user-images.githubusercontent.com/45588799/209318531-9e0aec6e-ea2e-4771-8a9f-995531282b3e.png)
