### PR TITLE
Fixes tooltip crash

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -4,7 +4,7 @@ import { useAtom } from 'jotai';
 import React, { useState } from 'react';
 import { HiXMark } from 'react-icons/hi2';
 import { useTranslation } from 'translation/translation';
-import { ZoneDetail } from 'types';
+import { ElectricityModeType, ZoneDetail } from 'types';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
@@ -32,7 +32,7 @@ function BarBreakdownChart() {
   const isBiggerThanMobile = useBreakpoint('sm');
 
   const [tooltipData, setTooltipData] = useState<{
-    selectedLayerKey: string;
+    selectedLayerKey: ElectricityModeType;
     x: number;
     y: number;
   } | null>(null);
@@ -54,7 +54,11 @@ function BarBreakdownChart() {
     );
   }
 
-  const onMouseOver = (layerKey: string, _: ZoneDetail, event: React.MouseEvent) => {
+  const onMouseOver = (
+    layerKey: ElectricityModeType,
+    _: ZoneDetail,
+    event: React.MouseEvent
+  ) => {
     const { clientX, clientY } = event;
 
     const position = getOffsetTooltipPosition({

--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
@@ -4,13 +4,13 @@ import { max as d3Max } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { useMemo } from 'react';
 import { useTranslation } from 'translation/translation';
-import { ZoneDetail } from 'types';
+import { ElectricityModeType, ZoneDetail } from 'types';
 import { modeColor } from 'utils/constants';
 import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
-import { ExchangeDataType, getDataBlockPositions, ProductionDataType } from './utils';
+import { ExchangeDataType, ProductionDataType, getDataBlockPositions } from './utils';
 
 interface BarBreakdownEmissionsChartProps {
   height: number;
@@ -20,13 +20,13 @@ interface BarBreakdownEmissionsChartProps {
   productionData: ProductionDataType[];
   isMobile: boolean;
   onProductionRowMouseOver: (
-    mode: string,
+    mode: ElectricityModeType,
     data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onProductionRowMouseOut: () => void;
   onExchangeRowMouseOver: (
-    mode: string,
+    mode: ElectricityModeType,
     data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;

--- a/web/src/features/charts/bar-breakdown/BarBreakdownProductionChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownProductionChart.tsx
@@ -13,9 +13,9 @@ import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
 import {
   ExchangeDataType,
+  ProductionDataType,
   getDataBlockPositions,
   getElectricityProductionValue,
-  ProductionDataType,
 } from './utils';
 
 interface BarBreakdownProductionChartProps {
@@ -33,7 +33,7 @@ interface BarBreakdownProductionChartProps {
   ) => void;
   onProductionRowMouseOut: () => void;
   onExchangeRowMouseOver: (
-    mode: string,
+    mode: ElectricityModeType,
     data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;

--- a/web/src/features/charts/graphUtils.test.ts
+++ b/web/src/features/charts/graphUtils.test.ts
@@ -1,0 +1,66 @@
+import { getElectricityProductionValue, getRatioPercent } from './graphUtils';
+
+describe('getRatioPercent', () => {
+  it('handles 0 of 0', () => {
+    const actual = getRatioPercent(0, 0);
+    expect(actual).toEqual(0);
+  });
+  it('handles 10 of 0', () => {
+    const actual = getRatioPercent(10, 0);
+    expect(actual).toEqual('?');
+  });
+  it('handles 0 of 10', () => {
+    const actual = getRatioPercent(0, 10);
+    expect(actual).toEqual(0);
+  });
+  it('handles 5 of 5', () => {
+    const actual = getRatioPercent(5, 5);
+    expect(actual).toEqual(100);
+  });
+  it('handles 1 of 5', () => {
+    const actual = getRatioPercent(1, 5);
+    expect(actual).toEqual(20);
+  });
+});
+
+describe('getElectricityProductionValue', () => {
+  it('handles production', () => {
+    const actual = getElectricityProductionValue({
+      generationTypeCapacity: 61_370,
+      isStorage: false,
+      generationTypeStorage: undefined,
+      generationTypeProduction: 41_161,
+    });
+    expect(actual).toEqual(41_161);
+  });
+
+  it('handles storage', () => {
+    const actual = getElectricityProductionValue({
+      generationTypeCapacity: 20_222.25,
+      isStorage: true,
+      generationTypeStorage: -3738.75,
+      generationTypeProduction: 11_930.25,
+    });
+    expect(actual).toEqual(3738.75);
+  });
+
+  it('handles zero production', () => {
+    const actual = getElectricityProductionValue({
+      generationTypeCapacity: 123,
+      isStorage: false,
+      generationTypeStorage: undefined,
+      generationTypeProduction: 0,
+    });
+    expect(actual).toEqual(0);
+  });
+
+  it('handles null production', () => {
+    const actual = getElectricityProductionValue({
+      generationTypeCapacity: 16,
+      isStorage: false,
+      generationTypeStorage: undefined,
+      generationTypeProduction: null,
+    });
+    expect(actual).toEqual(null);
+  });
+});

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -113,7 +113,7 @@ export function getElectricityProductionValue({
   generationTypeProduction,
   generationTypeStorage,
 }: {
-  generationTypeCapacity: Maybe<number> | undefined;
+  generationTypeCapacity: Maybe<number>;
   isStorage: boolean;
   generationTypeProduction: Maybe<number>;
   generationTypeStorage: Maybe<number>;

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -5,7 +5,7 @@ import { bisectLeft } from 'd3-array';
 
 import { scaleTime } from 'd3-scale';
 import { pointer } from 'd3-selection';
-import { ElectricityStorageType, GenerationType, ZoneDetail } from 'types';
+import { ElectricityStorageType, GenerationType, Maybe, ZoneDetail } from 'types';
 import { modeOrder } from 'utils/constants';
 
 export const detectHoveredDatapointIndex = (
@@ -101,7 +101,7 @@ export function getRatioPercent(value: number, total: number) {
   if (value === 0 && total === 0) {
     return 0;
   }
-  if (!Number.isFinite(value) || !Number.isFinite(total)) {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total === 0) {
     return '?';
   }
   return Math.round((value / total) * 10_000) / 100;
@@ -113,12 +113,15 @@ export function getElectricityProductionValue({
   generationTypeProduction,
   generationTypeStorage,
 }: {
-  generationTypeCapacity: number;
+  generationTypeCapacity: Maybe<number> | undefined;
   isStorage: boolean;
-  generationTypeProduction: number;
-  generationTypeStorage: number;
+  generationTypeProduction: Maybe<number>;
+  generationTypeStorage: Maybe<number>;
 }) {
-  const value = isStorage ? -generationTypeStorage : generationTypeProduction;
+  const value =
+    isStorage && generationTypeStorage
+      ? -generationTypeStorage
+      : generationTypeProduction;
   // If the value is not defined but the capacity
   // is zero, assume the value is also zero.
   if (!Number.isFinite(value) && generationTypeCapacity === 0) {

--- a/web/src/features/charts/tooltipCalculations.test.ts
+++ b/web/src/features/charts/tooltipCalculations.test.ts
@@ -168,11 +168,52 @@ describe('getProductionTooltipData', () => {
   it('returns 0 usage for zero production', () => {
     const actual = getProductionTooltipData('solar', zoneDetailsData, false);
     expect(actual.usage).toEqual(0);
+    expect(actual.emissions).toEqual(0);
   });
 
   it('returns nan usage for null production', () => {
     const actual = getProductionTooltipData('geothermal', zoneDetailsData, false);
     expect(actual.usage).toEqual(Number.NaN);
+  });
+
+  it('handles data with all production modes missing', () => {
+    const zoneDetailsDataWithMissingProductionModes = {
+      ...zoneDetailsData,
+      production: Object.fromEntries(
+        Object.keys(zoneDetailsData.production).map((key) => [key, null])
+      ),
+    } as unknown as ZoneDetail;
+    const data = getProductionTooltipData(
+      'nuclear',
+      zoneDetailsDataWithMissingProductionModes,
+      false
+    );
+    const expectedData = {
+      capacity: 61_370,
+      co2Intensity: 5.13,
+      co2IntensitySource: 'UNECE 2022',
+      displayByEmissions: false,
+      totalElectricity: 84_545.75,
+      totalEmissions: 13_208_019_616.973_745,
+      production: null,
+      zoneKey: 'FR',
+      storage: undefined,
+      isExport: false,
+      emissions: Number.NaN,
+      usage: Number.NaN,
+    };
+    expect(data).toEqual(expectedData);
+  });
+
+  it('handles missing capacity', () => {
+    const { capacity: _, ...zoneDetailsDataWithoutCapacity } = zoneDetailsData;
+    const actual = getProductionTooltipData(
+      'nuclear',
+      zoneDetailsDataWithoutCapacity,
+      false
+    );
+
+    expect(actual.usage).toEqual(41_161);
   });
 });
 

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -32,7 +32,7 @@ export function getProductionTooltipData(
     ? (dischargeCo2IntensitySources || {})[storageKey]
     : (productionCo2IntensitySources || {})[generationType];
 
-  const generationTypeCapacity = capacity[generationType];
+  const generationTypeCapacity = capacity ? capacity[generationType] : undefined;
   const generationTypeProduction = production[generationType];
 
   const generationTypeStorage = storageKey ? storage[storageKey] : 0;
@@ -43,12 +43,12 @@ export function getProductionTooltipData(
     generationTypeStorage,
     generationTypeProduction,
   });
-  const isExport = electricity < 0;
+  const isExport = electricity ? electricity < 0 : false;
 
-  let usage = Number.NaN;
-  let emissions = Number.NaN;
+  let usage = electricity === 0 ? 0 : Number.NaN;
+  let emissions = electricity === 0 ? 0 : Number.NaN;
 
-  if (Number.isFinite(electricity)) {
+  if (electricity && Number.isFinite(electricity)) {
     usage = Math.abs(
       displayByEmissions ? electricity * co2Intensity * 1000 : electricity
     );

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import AreaGraphToolTipHeader from 'stories/tooltips/AreaGraphTooltipHeader';
 import { getZoneName, useTranslation } from 'translation/translation';
-import { ZoneDetail } from 'types';
-import { modeColor, modeOrder, TimeAverages } from 'utils/constants';
+import { ElectricityModeType, ZoneDetail } from 'types';
+import { TimeAverages, modeColor, modeOrder } from 'utils/constants';
 import { formatCo2, formatPower } from 'utils/formatting';
 import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
 import { getRatioPercent } from '../graphUtils';
@@ -16,7 +16,7 @@ import { getExchangeTooltipData, getProductionTooltipData } from '../tooltipCalc
 import { InnerAreaGraphTooltipProps } from '../types';
 
 function calculateTooltipContentData(
-  selectedLayerKey: string,
+  selectedLayerKey: ElectricityModeType,
   zoneDetail: ZoneDetail,
   displayByEmissions: boolean
 ) {

--- a/web/src/features/charts/types.ts
+++ b/web/src/features/charts/types.ts
@@ -1,4 +1,4 @@
-import { ZoneDetail } from 'types';
+import { ElectricityModeType, ZoneDetail } from 'types';
 
 export interface AreaGraphElement {
   datetime: Date;
@@ -8,5 +8,5 @@ export interface AreaGraphElement {
 
 export interface InnerAreaGraphTooltipProps {
   zoneDetail: ZoneDetail;
-  selectedLayerKey: string;
+  selectedLayerKey: ElectricityModeType;
 }

--- a/web/src/stories/tooltips/BreakdownChartTooltip.stories.ts
+++ b/web/src/stories/tooltips/BreakdownChartTooltip.stories.ts
@@ -131,6 +131,25 @@ export const Example: Story = {
   },
 };
 
+export const WithoutCapacity: Story = {
+  // More on args: https://storybook.js.org/docs/react/writing-stories/args
+  args: {
+    datetime: new Date(zoneDetailMock.stateDatetime),
+    usage: 599,
+    timeAverage: TimeAverages.HOURLY,
+    capacity: undefined,
+    co2Intensity: 130,
+    co2IntensitySource: 'IPCC 2014; EU-ETS, ENTSO-E 2021',
+    displayByEmissions: false,
+    emissions: 100_000_000,
+    totalElectricity: 1100,
+    totalEmissions: 1_200_000_000,
+    selectedLayerKey: 'nuclear',
+    zoneKey: 'DK-DK1',
+    originTranslateKey: 'electricityComesFrom',
+  },
+};
+
 export const isStoring: Story = {
   // More on args: https://storybook.js.org/docs/react/writing-stories/args
   args: {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -81,7 +81,7 @@ export type Exchange = { [key: string]: number };
 
 export interface ZoneDetail extends ZoneOverview {
   _isFinestGranularity: boolean;
-  capacity: { [key in ElectricityModeType]: Maybe<number> };
+  capacity?: { [key in ElectricityModeType]: Maybe<number> };
   dischargeCo2Intensities: { [key in ElectricityStorageKeyType]: number };
   dischargeCo2IntensitySources: { [key in ElectricityStorageKeyType]: string };
   exchange: Exchange;


### PR DESCRIPTION
## Issue

https://linear.app/electricitymaps/issue/ELE-1536/chart-tooltip-breaks-any-aggregate-but-hourly

## Description

Fixes the crashing tooltips on non-hourly view. I had a hard time understanding what's going on here, so I added more tests to make sure it (hopefully) still works 😄 
