### PR TITLE
allow toggle between production and consumption

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -14,7 +14,7 @@ import WindLayer from 'features/weather-layers/wind-layer/WindLayer';
 import { useAtom, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { createToWithState, getCO2IntensityByMode } from 'utils/helpers';
-import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
+import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import CustomLayer from './map-utils/CustomLayer';
 import { useGetGeometries } from './map-utils/getMapGrid';
 import {
@@ -24,6 +24,7 @@ import {
   mousePositionAtom,
 } from './mapAtoms';
 import { FeatureId } from './mapTypes';
+import { Mode } from 'utils/constants';
 
 const ZONE_SOURCE = 'zones-clickable';
 const SOUTHERN_LATITUDE_BOUND = -66.947_193;
@@ -49,6 +50,8 @@ export default function MapPage(): ReactElement {
   const getCo2colorScale = useCo2ColorScale();
   const navigate = useNavigate();
   const theme = useTheme();
+  const [currentMode] = useAtom(productionConsumptionAtom);
+  const mixMode = currentMode === Mode.CONSUMPTION ? 'consumption' : 'production';
 
   // Calculate layer styles only when the theme changes
   // To keep the stable and prevent excessive rerendering.
@@ -109,7 +112,7 @@ export default function MapPage(): ReactElement {
       const zone = data.data?.zones[zoneId];
       const co2intensity =
         zone && zone[selectedDatetime.datetimeString]
-          ? getCO2IntensityByMode(zone[selectedDatetime.datetimeString], 'consumption')
+          ? getCO2IntensityByMode(zone[selectedDatetime.datetimeString], mixMode)
           : undefined;
 
       const fillColor = co2intensity
@@ -133,7 +136,7 @@ export default function MapPage(): ReactElement {
         );
       }
     }
-  }, [mapReference, geometries, data, getCo2colorScale, selectedDatetime]);
+  }, [mapReference, geometries, data, getCo2colorScale, selectedDatetime, mixMode]);
 
   useEffect(() => {
     const map = mapReference.current?.getMap();

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -1,6 +1,9 @@
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
+import { productionConsumptionAtom } from 'utils/state/atoms';
+import { Mode } from 'utils/constants';
+import { useAtom } from 'jotai';
 
 interface ZoneHeaderProps {
   zoneId: string;
@@ -9,6 +12,9 @@ interface ZoneHeaderProps {
   co2intensity?: number;
   renewableRatio?: number;
   fossilFuelRatio?: number;
+  co2intensityProduction?: number;
+  renewableRatioProduction?: number;
+  fossilFuelRatioProduction?: number;
 }
 
 export function ZoneHeader({
@@ -18,7 +24,16 @@ export function ZoneHeader({
   co2intensity,
   renewableRatio,
   fossilFuelRatio,
+  co2intensityProduction,
+  renewableRatioProduction,
+  fossilFuelRatioProduction,
 }: ZoneHeaderProps) {
+  const [currentMode] = useAtom(productionConsumptionAtom);
+  const isConsumption = currentMode === Mode.CONSUMPTION;
+  const intensity = isConsumption ? co2intensity : co2intensityProduction;
+  const renewable = isConsumption ? renewableRatio : renewableRatioProduction;
+  const fossilFuel = isConsumption ? fossilFuelRatio : fossilFuelRatioProduction;
+
   return (
     <div className="mt-1 grid w-full gap-y-5 sm:pr-4">
       <ZoneHeaderTitle
@@ -27,12 +42,12 @@ export function ZoneHeader({
         isAggregated={isAggregated}
       />
       <div className="flex flex-row justify-evenly">
-        <CarbonIntensitySquare co2intensity={co2intensity ?? Number.NaN} withSubtext />
+        <CarbonIntensitySquare co2intensity={intensity ?? Number.NaN} withSubtext />
         <CircularGauge
           name="Low-carbon"
-          ratio={fossilFuelRatio ? 1 - fossilFuelRatio : Number.NaN}
+          ratio={fossilFuel ? 1 - fossilFuel : Number.NaN}
         />
-        <CircularGauge name="Renewable" ratio={renewableRatio ?? Number.NaN} />
+        <CircularGauge name="Renewable" ratio={renewable ?? Number.NaN} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1542/fix-product-consumption-toggle-again
## Description
I don't think it was broken, just not implemented. I've added it to the map and the Zone Detail header. Is there anywhere else?

