### PR TITLE
add get our data link

### DIFF
--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -2,6 +2,7 @@ import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { formatTimeRange } from 'utils/formatting';
 import { timeAverageAtom } from 'utils/state/atoms';
+import { HiOutlineArrowDownTray } from 'react-icons/hi2';
 
 type Props = {
   translationKey: string;
@@ -21,13 +22,26 @@ export function ChartTitle({ translationKey }: Props) {
   Use local for timeAverage if exists, otherwise use local default if exists. If no translation exists, use english
   */
   return (
-    <h3 className="text-md">
-      {localExists
-        ? __(`${translationKey}.${timeAverage}`)
-        : __(
-            `${translationKey}.default`,
-            formatTimeRange(localDefaultExists ? i18n.language : 'en', timeAverage)
-          )}
-    </h3>
+    <>
+      <h3 className="pt-3 pb-1 text-md">
+        {localExists
+          ? __(`${translationKey}.${timeAverage}`)
+          : __(
+              `${translationKey}.default`,
+              formatTimeRange(localDefaultExists ? i18n.language : 'en', timeAverage)
+            )}
+      </h3>
+      <div className="message flex flex-row items-center pb-2 text-xs no-underline">
+        <HiOutlineArrowDownTray size={12} />
+        <a
+          href="https://electricitymaps.com/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel"
+          target="_blank"
+          rel="noreferrer"
+          className="pl-0.5"
+        >
+          {__('country-history.Getdata')}
+        </a>
+      </div>
+    </>
   );
 }

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -31,13 +31,13 @@ export function ChartTitle({ translationKey }: Props) {
               formatTimeRange(localDefaultExists ? i18n.language : 'en', timeAverage)
             )}
       </h3>
-      <div className="message flex flex-row items-center pb-2 text-xs no-underline">
-        <HiOutlineArrowDownTray size={12} />
+      <div className=" flex flex-row items-center pb-2 text-center text-sm  ">
+        <HiOutlineArrowDownTray className="min-w-[12px]" size={12} />
         <a
           href="https://electricitymaps.com/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel"
           target="_blank"
           rel="noreferrer"
-          className="pl-0.5"
+          className="whitespace-nowrap pl-0.5 text-sky-600 no-underline hover:underline  dark:invert"
         >
           {__('country-history.Getdata')}
         </a>

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -34,7 +34,7 @@ export function ChartTitle({ translationKey }: Props) {
       <div className=" flex flex-row items-center pb-2 text-center text-sm  ">
         <HiOutlineArrowDownTray className="min-w-[12px]" size={12} />
         <a
-          href="https://electricitymaps.com/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel"
+          href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
           target="_blank"
           rel="noreferrer"
           className="whitespace-nowrap pl-0.5 text-sky-600 no-underline hover:underline  dark:invert"

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -1,4 +1,3 @@
-import { PulseLoader } from 'react-spinners';
 import { TimeAverages } from 'utils/constants';
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
@@ -22,6 +21,9 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   const { chartData, layerFill, layerKeys, layerStroke, valueAxisLabel, markerFill } =
     data;
 
+  if (!chartData[24].layerData.price) {
+    return null;
+  }
   return (
     <>
       <ChartTitle translationKey="country-history.electricityprices" />

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -21,7 +21,7 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   const { chartData, layerFill, layerKeys, layerStroke, valueAxisLabel, markerFill } =
     data;
 
-  if (!chartData[24].layerData.price) {
+  if (!chartData[0]?.layerData?.price) {
     return null;
   }
   return (

--- a/web/src/features/panels/zone/Attribution.tsx
+++ b/web/src/features/panels/zone/Attribution.tsx
@@ -36,13 +36,14 @@ export default function Attribution({
   }, [dataSources, i18n.language]);
 
   return (
-    <div className="message text-sm no-underline">
+    <div className="whitespace-nowrap text-sm ">
       <span>{__('country-panel.source')}:</span>
       <a
         style={{ textDecoration: 'none' }}
         href="https://github.com/electricitymaps/electricitymaps-contrib#data-sources/blob/master/DATA_SOURCES.md#real-time-electricity-data-sources"
         target="_blank"
         rel="noreferrer"
+        className="text-sky-600 no-underline hover:underline dark:invert"
       >
         {' '}
         <span className="hover:underline">{formattedDataSources || '?'}</span>
@@ -51,8 +52,7 @@ export default function Attribution({
         {' '}
         (
         <span
-          className="text-sm"
-          style={{ textDecoration: 'none' }}
+          className="text-sm text-sky-600 no-underline hover:underline dark:invert"
           dangerouslySetInnerHTML={{
             __html: __(
               'country-panel.addeditsource',

--- a/web/src/features/panels/zone/NoInformationMessage.tsx
+++ b/web/src/features/panels/zone/NoInformationMessage.tsx
@@ -5,7 +5,7 @@ export default function NoInformationMessage() {
   return (
     <div data-test-id="no-parser-message" className="pt-4 text-base">
       <span
-        className="message"
+        className="text-sm text-sky-600 no-underline hover:underline dark:invert"
         dangerouslySetInnerHTML={{
           __html: __(
             'country-panel.noParserInfo',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -110,13 +110,6 @@ body,
   @apply h-full;
 }
 
-.message a {
-  @apply text-blue-400;
-  @apply hover:text-blue-600;
-  @apply hover:underline;
-  @apply no-underline;
-  @apply dark:hover:text-blue-400;
-}
 
 noscript div {
   height: 100vh;


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1553/add-get-our-data-to-link-above-charts-improve-spacing
## Description
Adds a new link with improved spacing as a subtitle to the charts. Also doesn't render the price chart title when there is no price chart.