### PR TITLE
time controller german translation

### DIFF
--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -51,6 +51,9 @@
     "zone-list-header-subtitle": "Sortiert nach CO₂-Intensität der verfügbaren Elektrizität (gCO₂äq/kWh)",
     "search": "Land oder Region suchen"
   },
+  "time-controller": {
+    "title": "Daten aus der Vergangenheit anzeigen"
+  },
   "country-history": {
     "Getdata": "Zugang zu historischen Daten und zur Vorhersage-API",
     "carbonintensity": { "hourly": "spezifische CO₂-Emissionen in den letzten 24 h" },

--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -52,7 +52,7 @@
     "search": "Land oder Region suchen"
   },
   "time-controller": {
-    "title": "Daten aus der Vergangenheit anzeigen"
+    "title": "Historische Daten anzeigen"
   },
   "country-history": {
     "Getdata": "Zugang zu historischen Daten und zur Vorhersage-API",


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1578/new-feature-german-for-time-selector
## Description
Adds a German translation for the time selector, this is a google translation and a native German speaker should validate.

@ciril-emaps Do you understand german?

If so, is this an effective translation of "Display data from the past"
