### PR TITLE
show production / consumption in carbon tooltip

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -80,7 +80,7 @@ interface AreagraphProps {
   height: string;
   datetimes: Date[];
   selectedTimeAggregate: TimeAverages; // TODO: Graph does not need to know about this
-  tooltip: (props: InnerAreaGraphTooltipProps) => JSX.Element;
+  tooltip: (props: InnerAreaGraphTooltipProps) => JSX.Element | null;
   tooltipSize?: 'small' | 'large';
 }
 

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -4,28 +4,31 @@ import { useCo2ColorScale } from 'hooks/theme';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from 'utils/formatting';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { productionConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
 import { InnerAreaGraphTooltipProps } from '../types';
+import { Mode } from 'utils/constants';
 
 export default function CarbonChartTooltip(props: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);
   const { i18n } = useTranslation();
   const { zoneDetail } = props;
+  const [currentMode] = useAtom(productionConsumptionAtom);
+  const isConsumption = currentMode === Mode.CONSUMPTION;
 
   const co2ColorScale = useCo2ColorScale();
 
   if (!zoneDetail) {
     return null;
   }
-  const { co2intensity, stateDatetime } = zoneDetail;
-
+  const { co2intensity, co2intensityProduction, stateDatetime } = zoneDetail;
+  const intensity = isConsumption ? co2intensity ?? 0 : co2intensityProduction ?? 0;
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-80">
       <div className="flex justify-between">
         <div className="inline-flex items-center gap-x-1">
           <div
             style={{
-              backgroundColor: co2ColorScale(co2intensity),
+              backgroundColor: co2ColorScale(intensity),
             }}
             className="h-[16px] w-[16px] rounded-sm"
           ></div>
@@ -37,7 +40,7 @@ export default function CarbonChartTooltip(props: InnerAreaGraphTooltipProps) {
       </div>
       <hr className="my-1 mb-3" />
       <p className="flex justify-center text-base">
-        <CarbonIntensityDisplay co2Intensity={co2intensity} />
+        <CarbonIntensityDisplay co2Intensity={intensity} />
       </p>
     </div>
   );

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -21,8 +21,7 @@ export default function CarbonChartTooltip(props: InnerAreaGraphTooltipProps) {
     return null;
   }
   const { co2intensity, co2intensityProduction, stateDatetime } = zoneDetail;
-  const intensity = isConsumption ? co2intensity ?? 0 : co2intensityProduction ?? 0;
-  const intensity = (isConsumption ? co2intensity: co2intensityProduction) ?? 0;
+  const intensity = (isConsumption ? co2intensity : co2intensityProduction) ?? 0;
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-80">
       <div className="flex justify-between">

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -22,6 +22,7 @@ export default function CarbonChartTooltip(props: InnerAreaGraphTooltipProps) {
   }
   const { co2intensity, co2intensityProduction, stateDatetime } = zoneDetail;
   const intensity = isConsumption ? co2intensity ?? 0 : co2intensityProduction ?? 0;
+  const intensity = (isConsumption ? co2intensity: co2intensityProduction) ?? 0;
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-80">
       <div className="flex justify-between">


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1575/make-chart-tooltips-respect-the-consumption-production-toggle
## Description
Carbon breakdown tooltip was not respecting the production / consumption toggle