### PR TITLE
add spacing for units

### DIFF
--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -52,7 +52,7 @@ function CarbonIntensitySquare({
           className="mx-auto flex h-[65px] w-[65px] flex-col items-center justify-center rounded-2xl text-md"
         >
           <p className="select-none text-md font-bold" data-test-id="co2-square-value">
-            <animated.span>{number.to((x) => `${Math.round(x) || '?'}g`)}</animated.span>
+            <animated.span>{number.to((x) => `${Math.round(x) || '?'} g`)}</animated.span>
           </p>
         </animated.div>
       </div>

--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -14,7 +14,8 @@ export function CarbonIntensity({ intensity }: { intensity?: number }) {
         className="mr-1 h-3 w-3"
         style={{ backgroundColor: co2ColorScale(intensity ?? 0) }}
       />
-      <b className="flex items-center">{Math.round(intensity ?? 0) || '?'}</b> gCO₂eq/kWh
+      <b className="flex items-center">{Math.round(intensity ?? 0) || '?'}</b>
+      <p className="pl-0.5"> gCO₂eq/kWh</p>
     </div>
   );
 }
@@ -38,7 +39,7 @@ export default function ExchangeTooltip(
       {__('tooltips.crossborderexport')}:
       <div className="flex items-center p-1">
         <ZoneName zone={zoneFrom} /> <p className="m-2">→</p> <ZoneName zone={zoneTo} />
-        <b className="pt-0 text-xs ">:{formatPower(roundedNetFlow)}</b>
+        <b className="pt-0 text-xs ">: {formatPower(roundedNetFlow)}</b>
       </div>
       {__('tooltips.carbonintensityexport')}:
       <div className="p-1">

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -9,7 +9,10 @@ export const formatPower = function (d: number, numberDigits = DEFAULT_NUM_DIGIT
   if (d == undefined || Number.isNaN(d)) {
     return d;
   }
-  return `${d3.format(`.${numberDigits}s`)(d * 1e6)}W`;
+  const power = `${d3.format(`.${numberDigits}s`)(d * 1e6)}W` //Add a space between the number and the unit
+    .replace(/([A-Z])/, ' $1')
+    .trim();
+  return power;
 };
 
 export const formatCo2 = function (d, numberDigits = DEFAULT_NUM_DIGITS) {


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1557/app-inconsistent-spacing-on-numbers-and-units-throughout-the-app
## Description
Improves the spacing to add consistency of spacing between units, gathered some feedback from sciency and designy people in the office :)
