### PR TITLE
Adds tooltip to LowCarbon Gauge in panel

### DIFF
--- a/web/src/components/CircularGauge.stories.tsx
+++ b/web/src/components/CircularGauge.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { HiMagnifyingGlass } from 'react-icons/hi2';
+import { CircularGauge } from './CircularGauge';
+
+const meta: Meta<typeof CircularGauge> = {
+  title: 'Basics/CircularGauge',
+  component: CircularGauge,
+};
+
+export default meta;
+type Story = StoryObj<typeof CircularGauge>;
+
+export const Default: Story = {
+  argTypes: {
+    ratio: {
+      control: { type: 'number', min: 0, max: 1, step: 0.1 },
+    },
+  },
+  args: {
+    ratio: 0.5,
+    name: 'Renewable',
+  },
+};
+
+export const WithTooltip: Story = {
+  argTypes: {
+    ratio: {
+      control: { type: 'number', min: 0, max: 1, step: 0.1 },
+    },
+  },
+  args: {
+    tooltipContent: (
+      <div>
+        Hello <strong>friend</strong>
+      </div>
+    ),
+    ratio: 0.5,
+    name: 'Renewable',
+  },
+};

--- a/web/src/components/CircularGauge.tsx
+++ b/web/src/components/CircularGauge.tsx
@@ -1,13 +1,15 @@
 import { Label, Pie, PieChart } from 'recharts';
+import TooltipWrapper from './tooltips/TooltipWrapper';
 
 const PIE_START_ANGLE = 90;
 
 export interface CircularGaugeProps {
   ratio: number;
   name: string;
+  tooltipContent?: string | JSX.Element;
 }
 
-export function CircularGauge({ ratio, name }: CircularGaugeProps) {
+export function CircularGauge({ ratio, name, tooltipContent }: CircularGaugeProps) {
   // TODO: To improve performance, the background pie does not https://linear.app/electricitymaps/issue/ELE-1497/improve-gauge-animation-performance
   // need to rerender on percentage change
   const data = [{ value: ratio }];
@@ -16,43 +18,56 @@ export function CircularGauge({ ratio, name }: CircularGaugeProps) {
 
   return (
     <div className="flex flex-col items-center">
-      <PieChart width={65} height={65} margin={{ top: 0, left: 0, right: 0, bottom: 0 }}>
-        <Pie
-          innerRadius="80%"
-          outerRadius="100%"
-          startAngle={90}
-          endAngle={-360}
-          paddingAngle={0}
-          dataKey="value"
-          data={[{ value: 100 }]}
-          className="fill-gray-200/60 dark:fill-gray-600/50"
-          isAnimationActive={false}
-          strokeWidth={0}
-        >
-          <Label
-            className="select-none bg-red-500 fill-gray-900 font-bold dark:fill-gray-300"
-            position="center"
-            offset={0}
-            formatter={(value: number) =>
-              !Number.isNaN(value) ? `${Math.round(value * 100)}%` : '?%'
-            }
-            value={ratio}
-          />
-        </Pie>
-        <Pie
-          data={data}
-          innerRadius="80%"
-          outerRadius="100%"
-          startAngle={90}
-          endAngle={endAngle}
-          fill="#3C764A" // TODO: Use theme color
-          paddingAngle={0}
-          dataKey="value"
-          animationDuration={500}
-          animationBegin={0}
-          strokeWidth={0}
-        />
-      </PieChart>
+      <TooltipWrapper
+        side="right"
+        tooltipContent={tooltipContent}
+        tooltipClassName="bg-white"
+      >
+        {/* Div required to ensure Tooltip is rendered in right place */}
+        <div>
+          <PieChart
+            width={65}
+            height={65}
+            margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
+          >
+            <Pie
+              innerRadius="80%"
+              outerRadius="100%"
+              startAngle={90}
+              endAngle={-360}
+              paddingAngle={0}
+              dataKey="value"
+              data={[{ value: 100 }]}
+              className="fill-gray-200/60 dark:fill-gray-600/50"
+              isAnimationActive={false}
+              strokeWidth={0}
+            >
+              <Label
+                className="select-none bg-red-500 fill-gray-900 font-bold dark:fill-gray-300"
+                position="center"
+                offset={0}
+                formatter={(value: number) =>
+                  !Number.isNaN(value) ? `${Math.round(value * 100)}%` : '?%'
+                }
+                value={ratio}
+              />
+            </Pie>
+            <Pie
+              data={data}
+              innerRadius="80%"
+              outerRadius="100%"
+              startAngle={90}
+              endAngle={endAngle}
+              fill="#3C764A" // TODO: Use theme color
+              paddingAngle={0}
+              dataKey="value"
+              animationDuration={500}
+              animationBegin={0}
+              strokeWidth={0}
+            />
+          </PieChart>
+        </div>
+      </TooltipWrapper>
       <div className="mt-2 text-center text-sm text-gray-900 dark:text-gray-300">
         {name}
       </div>

--- a/web/src/components/CircularGauge.tsx
+++ b/web/src/components/CircularGauge.tsx
@@ -21,7 +21,7 @@ export function CircularGauge({ ratio, name, tooltipContent }: CircularGaugeProp
       <TooltipWrapper
         side="right"
         tooltipContent={tooltipContent}
-        tooltipClassName="bg-white"
+        tooltipClassName="bg-white max-w-44"
       >
         {/* Div required to ensure Tooltip is rendered in right place */}
         <div>

--- a/web/src/components/tooltips/TooltipWrapper.tsx
+++ b/web/src/components/tooltips/TooltipWrapper.tsx
@@ -1,5 +1,6 @@
-import { ReactElement } from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import { ReactElement } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 interface TooltipWrapperProperties {
   tooltipContent?: string | ReactElement;
@@ -22,10 +23,10 @@ export default function TooltipWrapper(
         <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
-            className={
-              tooltipClassName ??
-              'relative   h-auto max-w-[164px] rounded border bg-gray-100 p-1 px-3 text-center text-sm drop-shadow-sm dark:border-0 dark:bg-gray-900'
-            }
+            className={twMerge(
+              'relative h-auto max-w-[164px] rounded border bg-gray-100 p-1 px-3 text-center text-sm shadow-md dark:border-0 dark:bg-gray-900',
+              tooltipClassName
+            )}
             sideOffset={sideOffset ?? 3}
             side={side ?? 'left'}
           >

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -70,7 +70,7 @@ function ExchangeArrow({ data, viewportWidth, viewportHeight, map }: ExchangeArr
 
   return (
     <TooltipWrapper
-      tooltipClassName="relative flex max-h-[256px] max-w-[512px] top-[-76px] rounded border bg-gray-100 p-1 px-1  text-sm drop-shadow-sm dark:border-0 dark:bg-gray-900"
+      tooltipClassName="flex max-h-[256px] max-w-[512px] top-[-76px]  px-1"
       tooltipContent={<ExchangeTooltip exchangeData={data} />}
       side="right"
       sideOffset={10}

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -70,7 +70,7 @@ function ExchangeArrow({ data, viewportWidth, viewportHeight, map }: ExchangeArr
 
   return (
     <TooltipWrapper
-      tooltipClassName="flex max-h-[256px] max-w-[512px] top-[-76px]  px-1"
+      tooltipClassName="flex max-h-[256px] max-w-[512px] top-[-76px]  px-1 text-left"
       tooltipContent={<ExchangeTooltip exchangeData={data} />}
       side="right"
       sideOffset={10}

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -4,8 +4,8 @@ import { useAtom } from 'jotai';
 import useGetState from 'api/getState';
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
-import { getSafeTooltipPosition } from 'components/tooltips/utilities';
 import { ZoneName } from 'components/ZoneName';
+import { getSafeTooltipPosition } from 'components/tooltips/utilities';
 import { useTranslation } from 'translation/translation';
 import { Mode } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
@@ -44,7 +44,6 @@ function TooltipInner({
   } = zoneData;
   const [currentMode] = useAtom(productionConsumptionAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
-
   return (
     <div className="w-full p-4 text-center">
       <div className="pl-1">
@@ -59,7 +58,7 @@ function TooltipInner({
           <div className="px-4">
             <CircularGauge
               name="Low-carbon"
-              ratio={isConsumption ? fossilFuelRatio : fossilFuelRatioProduction}
+              ratio={1 - (isConsumption ? fossilFuelRatio : fossilFuelRatioProduction)}
             />
           </div>
           <CircularGauge

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -1,9 +1,22 @@
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
-import ZoneHeaderTitle from './ZoneHeaderTitle';
-import { productionConsumptionAtom } from 'utils/state/atoms';
-import { Mode } from 'utils/constants';
 import { useAtom } from 'jotai';
+import { useTranslation } from 'translation/translation';
+import { Mode } from 'utils/constants';
+import { productionConsumptionAtom } from 'utils/state/atoms';
+import ZoneHeaderTitle from './ZoneHeaderTitle';
+
+function LowCarbonTooltip() {
+  const { __ } = useTranslation();
+  return (
+    <div className="text-left">
+      <b>{__('tooltips.lowcarbon')}</b>
+      <br />
+      <small>{__('tooltips.lowCarbDescription')}</small>
+      <br />
+    </div>
+  );
+}
 
 interface ZoneHeaderProps {
   zoneId: string;
@@ -46,6 +59,7 @@ export function ZoneHeader({
         <CircularGauge
           name="Low-carbon"
           ratio={fossilFuel ? 1 - fossilFuel : Number.NaN}
+          tooltipContent={<LowCarbonTooltip />}
         />
         <CircularGauge name="Renewable" ratio={renewable ?? Number.NaN} />
       </div>


### PR DESCRIPTION
## Issue
https://linear.app/electricitymaps/issue/ELE-1558/add-tooltip-to-lowcarbon-gauge
## Description

Adds the tooltip. Thought we needed it in other places, so made the gauge support that - but maybe wasn't needed I see now 😬 

I also fixed a bug on the MapTooltip where the number was wrong.

### Preview

![Screenshot 2023-01-12 at 12 51 40](https://user-images.githubusercontent.com/3296643/212173393-2a7466fd-470f-4e78-a5ec-188d80e58700.png)

