### PR TITLE
unhover other zones on click

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -160,7 +160,6 @@ export default function MapPage(): ReactElement {
     }
   }, [isSuccess]);
   const onClick = (event: mapboxgl.MapLayerMouseEvent) => {
-    setHoveredZone(null);
     const map = mapReference.current?.getMap();
     if (!map || !event.features) {
       return;
@@ -176,6 +175,13 @@ export default function MapPage(): ReactElement {
       );
     }
 
+    if (hoveredZone && (!feature || hoveredZone.featureId !== feature.id)) {
+      map.setFeatureState(
+        { source: ZONE_SOURCE, id: hoveredZone.featureId },
+        { hover: false }
+      );
+    }
+    setHoveredZone(null);
     if (feature && feature.properties) {
       setSelectedFeatureId(feature.id);
       map.setFeatureState({ source: ZONE_SOURCE, id: feature.id }, { selected: true });


### PR DESCRIPTION
## Issue

## Description
The fly to zone feature could leave zones in a hovered state, this PR unhovers zones that are not the zone being clicked
