### PR TITLE
Minor fixes

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -913,15 +913,15 @@
     },
     "IT-CNO": {
       "countryName": "Italy",
-      "zoneName": "Central North"
+      "zoneName": "Central North Italy"
     },
     "IT-CSO": {
       "countryName": "Italy",
-      "zoneName": "Central South"
+      "zoneName": "Central South Italy"
     },
     "IT-NO": {
       "countryName": "Italy",
-      "zoneName": "North"
+      "zoneName": "North Italy"
     },
     "IT-SAR": {
       "countryName": "Italy",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,6 @@ import LegendContainer from 'components/legend/LegendContainer';
 import { OnboardingModal } from 'components/modals/OnboardingModal';
 import ErrorComponent from 'features/error-boundary/ErrorBoundary';
 import Header from 'features/header/Header';
-import MapControls from 'features/map-controls/MapControls';
 import FAQModal from 'features/modals/FAQModal';
 import InfoModal from 'features/modals/InfoModal';
 import SettingsModal from 'features/modals/SettingsModal';
@@ -52,7 +51,6 @@ export default function App(): ReactElement {
               <LeftPanel />
               <MapWrapper />
               <TimeControllerWrapper />
-              <MapControls />
               <LegendContainer />
             </Sentry.ErrorBoundary>
           </div>

--- a/web/src/components/legend/LegendContainer.tsx
+++ b/web/src/components/legend/LegendContainer.tsx
@@ -1,13 +1,13 @@
+import { useAtom } from 'jotai';
 import type { ReactElement } from 'react';
-import Co2Legend from './Co2Legend';
+import { ToggleOptions } from 'utils/constants';
 import {
   selectedDatetimeIndexAtom,
   solarLayerEnabledAtom,
   windLayerAtom,
 } from 'utils/state/atoms';
-import { useAtom } from 'jotai';
+import Co2Legend from './Co2Legend';
 import SolarLegend from './SolarLegend';
-import { ToggleOptions } from 'utils/constants';
 import WindLegend from './WindLegend';
 
 export default function LegendContainer(): ReactElement {
@@ -21,7 +21,7 @@ export default function LegendContainer(): ReactElement {
     windLayerToggle === ToggleOptions.ON && selectedDatetime.index === 24;
 
   return (
-    <div className="invisible fixed bottom-4 right-4 z-50 flex w-[224px]  flex-col rounded bg-white px-1 py-2 shadow dark:bg-gray-900 sm:visible ">
+    <div className="invisible fixed bottom-4 right-4 z-20 flex w-[224px]  flex-col rounded bg-white px-1 py-2 shadow-xl dark:bg-gray-900 sm:visible ">
       {isSolarLayerEnabled && <SolarLegend />}
       {isWindLayerEnabled && <WindLegend />}
       <Co2Legend />

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -1,9 +1,14 @@
-import { ElectricityStorageKeyType, GenerationType, ZoneDetail } from 'types';
+import {
+  ElectricityModeType,
+  ElectricityStorageKeyType,
+  GenerationType,
+  ZoneDetail,
+} from 'types';
 import { getProductionCo2Intensity } from 'utils/helpers';
 import { getElectricityProductionValue, getTotalElectricity } from './graphUtils';
 
 export function getProductionTooltipData(
-  selectedLayerKey: string,
+  selectedLayerKey: ElectricityModeType,
   zoneDetail: ZoneDetail,
   displayByEmissions: boolean
 ) {
@@ -32,7 +37,7 @@ export function getProductionTooltipData(
     ? (dischargeCo2IntensitySources || {})[storageKey]
     : (productionCo2IntensitySources || {})[generationType];
 
-  const generationTypeCapacity = capacity ? capacity[generationType] : undefined;
+  const generationTypeCapacity = capacity ? capacity[selectedLayerKey] : undefined;
   const generationTypeProduction = production[generationType];
 
   const generationTypeStorage = storageKey ? storage[storageKey] : 0;
@@ -89,7 +94,7 @@ export function getExchangeTooltipData(
   const totalElectricity = getTotalElectricity(zoneDetail, displayByEmissions);
   const totalCapacity = exchangeCapacityRange
     ? Math.abs(exchangeCapacityRange[isExport ? 0 : 1])
-    : Number.NaN;
+    : undefined;
   const emissions = Math.abs(exchange * 1000 * co2Intensity);
   const totalEmissions = getTotalElectricity(zoneDetail, true);
 

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -6,7 +6,7 @@ import { useAtom } from 'jotai';
 import { renderToString } from 'react-dom/server';
 import AreaGraphToolTipHeader from 'stories/tooltips/AreaGraphTooltipHeader';
 import { getZoneName, useTranslation } from 'translation/translation';
-import { ElectricityModeType, ZoneDetail } from 'types';
+import { ElectricityModeType, Maybe, ZoneDetail } from 'types';
 import { TimeAverages, modeColor, modeOrder } from 'utils/constants';
 import { formatCo2, formatPower } from 'utils/formatting';
 import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
@@ -70,7 +70,7 @@ export default function BreakdownChartTooltip(props: InnerAreaGraphTooltipProps)
 interface BreakdownChartTooltipContentProperties {
   datetime: Date;
   usage: number;
-  capacity: number;
+  capacity: Maybe<number>;
   totalElectricity: number;
   totalEmissions: number;
   co2Intensity: number;
@@ -82,8 +82,8 @@ interface BreakdownChartTooltipContentProperties {
   isExchange: boolean;
   selectedLayerKey: string;
   co2IntensitySource?: string;
-  storage?: number;
-  production?: number;
+  storage?: Maybe<number>;
+  production?: Maybe<number>;
 }
 
 export function BreakdownChartTooltipContent(

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -321,10 +321,10 @@ export default function MapPage(): ReactElement {
         <WindLayer />
       </CustomLayer>
       <CustomLayer>
-        <SolarLayer />
+        <ExchangeLayer />
       </CustomLayer>
       <CustomLayer>
-        <ExchangeLayer />
+        <SolarLayer />
       </CustomLayer>
       <ZoomControls />
     </Map>

--- a/web/src/features/map/MapWrapper.tsx
+++ b/web/src/features/map/MapWrapper.tsx
@@ -1,3 +1,4 @@
+import MapControls from 'features/map-controls/MapControls';
 import Map from './Map';
 import MapTooltip from './MapTooltip';
 
@@ -6,6 +7,7 @@ export default function MapWrapper() {
     <>
       <MapTooltip />
       <Map />
+      <MapControls />
     </>
   );
 }


### PR DESCRIPTION
## Issue

- https://linear.app/electricitymaps/issue/ELE-1623/legend-overlaps-map-controls-on-smaller-screens
- https://linear.app/electricitymaps/issue/ELE-1599/hydro-storage-is-using-hydro-installed-capacity-in-tooltip
- https://linear.app/electricitymaps/issue/ELE-1580/glow-in-the-dark-exchange-arrows-when-using-solar-layer
- https://linear.app/electricitymaps/issue/ELE-1601/country-name-is-not-included-in-exchanges-between-subzones-or-subzone

## Description

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
