### PR TITLE
Squares and gauges now uses translations

### DIFF
--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -1,5 +1,5 @@
-// import { useTranslation } from '../helpers/translation';
 import { animated, useSpring } from '@react-spring/web';
+import { useTranslation } from 'translation/translation';
 import { useCo2ColorScale } from '../hooks/theme';
 
 /**
@@ -33,7 +33,7 @@ function CarbonIntensitySquare({
   co2intensity,
   withSubtext,
 }: CarbonIntensitySquareProps) {
-  // const { __ } = useTranslation();
+  const { __ } = useTranslation();
   const co2ColorScale = useCo2ColorScale();
   const styles = useSpring({ backgroundColor: co2ColorScale(co2intensity) });
   const { number } = useSpring({
@@ -61,7 +61,7 @@ function CarbonIntensitySquare({
         </animated.div>
       </div>
       <div className="mt-2 flex flex-col items-center">
-        <div className="text-sm">{'Carbon Intensity'}</div>
+        <div className="text-sm">{__('country-panel.carbonintensity')}</div>
         {withSubtext && <div className="text-sm">(gCO₂eq/kWh)</div>}
       </div>
     </div>

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -34,6 +34,8 @@ function TooltipInner({
     renewableRatio,
     renewableRatioProduction,
   } = zoneData;
+  const { __ } = useTranslation();
+
   const [currentMode] = useAtom(productionConsumptionAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
   const fossilFuel = (isConsumption ? fossilFuelRatio : fossilFuelRatioProduction) ?? 0;
@@ -49,10 +51,10 @@ function TooltipInner({
             co2intensity={isConsumption ? co2intensity : co2intensityProduction}
           />
           <div className="px-4">
-            <CircularGauge name="Low-carbon" ratio={1 - fossilFuel} />
+            <CircularGauge name={__('country-panel.lowcarbon')} ratio={1 - fossilFuel} />
           </div>
           <CircularGauge
-            name="Renewable"
+            name={__('country-panel.renewable')}
             ratio={isConsumption ? renewableRatio : renewableRatioProduction}
           />
         </div>

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -41,6 +41,7 @@ export function ZoneHeader({
   renewableRatioProduction,
   fossilFuelRatioProduction,
 }: ZoneHeaderProps) {
+  const { __ } = useTranslation();
   const [currentMode] = useAtom(productionConsumptionAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
   const intensity = isConsumption ? co2intensity : co2intensityProduction;
@@ -57,11 +58,14 @@ export function ZoneHeader({
       <div className="flex flex-row justify-evenly">
         <CarbonIntensitySquare co2intensity={intensity ?? Number.NaN} withSubtext />
         <CircularGauge
-          name="Low-carbon"
+          name={__('country-panel.lowcarbon')}
           ratio={1 - fossilFuel}
           tooltipContent={<LowCarbonTooltip />}
         />
-        <CircularGauge name="Renewable" ratio={renewable ?? Number.NaN} />
+        <CircularGauge
+          name={__('country-panel.renewable')}
+          ratio={renewable ?? Number.NaN}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Issue

https://github.com/electricitymaps/electricitymaps-contrib/issues/4955

## Description

We had hardcoded strings for the gauges and square. This PR fixes that

### Preview

<img width="450" alt="Screenshot 2023-01-18 at 16 50 19" src="https://user-images.githubusercontent.com/3296643/213220464-ad67ab6a-c133-44b5-aca9-26566fa9c753.png">
<img width="317" alt="Screenshot 2023-01-18 at 16 54 58" src="https://user-images.githubusercontent.com/3296643/213222428-2ac51e9f-a37f-4c88-93eb-ebb96a7f584c.png">
