### PR TITLE
Fix invalid href lang + add preconnects

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -94,16 +94,18 @@
     <link rel="alternate" href="https://app.electricitymaps.com?lang=ru" hreflang="ru" />
     <link rel="alternate" href="https://app.electricitymaps.com?lang=sk" hreflang="sk" />
     <link rel="alternate" href="https://app.electricitymaps.com?lang=sv" hreflang="sv" />
-    <link rel="alternate" href="https://app.electricitymaps.com?lang=vn" hreflang="vn" />
-    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-cn" hreflang="zh-cn" />
-    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-hk" hreflang="zh-hk" />
-    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-tw" hreflang="zh-tw" />
+    <link rel="alternate" href="https://app.electricitymaps.com?lang=vi" hreflang="vi" />
+    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-CN" hreflang="zh-CN" />
+    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-HK" hreflang="zh-HK" />
+    <link rel="alternate" href="https://app.electricitymaps.com?lang=zh-TW" hreflang="zh-TW" />
 
     <!-- Canonical -->
     <link rel="canonical" href="https://app.electricitymaps.com" />
 
     <!-- Pre-connect to backend to improve performance -->
-    <link rel="preconnect" href="https://app-backend.electricitymaps.com/" />
+    <link rel="preconnect" href="https://app-backend.electricitymap.org/" />
+    <link rel="preconnect" href="https://o192958.ingest.sentry.io" />
+    <link rel="preconnect" href="https://plausible.io" />
 
     <!-- Preload font files to improve performance-->
     <link rel="preload" href="/fonts/Poppins-Medium.woff2" as="font" type="font/woff2" crossorigin />
@@ -111,6 +113,7 @@
 
     <!-- Plausible -->
     <script defer data-domain="app.electricitymaps.com" src="https://plausible.io/js/plausible.local.js"></script>
+    <!-- Polyfill for .at() -->
     <script>
       if (![].at) {
         Array.prototype.at = function (n) {
@@ -130,6 +133,7 @@
         };
       }
     </script>
+    <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <noscript>
@@ -140,6 +144,5 @@
       </div>
     </noscript>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Issue
We where accidentally including a non valid language code that brought down or SEO score.
## Description
Fixes the above issue and adds preconnects for sentry and plausible as well as fixing the preconnect to the backend that still use our old domain (electricitymaps.org).

PS: I also moved the main bundle script tag to where vite puts it after build, makes the file a little easier to understand.
